### PR TITLE
Enhance tag parsing to handle malformed IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehydra",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "On-device PII anonymization module for high-privacy translation",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/pipeline/tagger.ts
+++ b/src/pipeline/tagger.ts
@@ -348,14 +348,15 @@ function buildFuzzyTagPatterns(): RegExp[] {
   // Pattern for type attribute: type = "VALUE" (flexible spacing and quotes)
   const typeAttr = `type${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}([A-Z_]+)${QUOTE_CHARS}`;
   // Pattern for id attribute: id = "VALUE" (flexible spacing and quotes)
-  const idAttr = `id${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(\\d+)${QUOTE_CHARS}`;
+  // Also handles malformed cases where /> or /&gt; got placed inside the quotes (e.g., id="7/>")
+  const idAttr = `id${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(\\d+)(?:\\/?(?:>|&gt;)?)?${QUOTE_CHARS}`;
   // Optional gender attribute
   const genderAttr = `(?:${FLEXIBLE_WS}gender${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(\\w+)${QUOTE_CHARS})?`;
   // Optional scope attribute
   const scopeAttr = `(?:${FLEXIBLE_WS}scope${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(\\w+)${QUOTE_CHARS})?`;
 
-  // Self-closing tag endings: />, / >, >, etc.
-  const selfClosing = `${FLEXIBLE_WS}\\/?${FLEXIBLE_WS}>`;
+  // Self-closing tag endings: />, / >, >, or nothing if already closed inside quotes
+  const selfClosing = `${FLEXIBLE_WS}\\/?${FLEXIBLE_WS}>?`;
 
   return [
     // type first with optional gender/scope: <PII type="X" gender="Y" scope="Z" id="N"/>


### PR DESCRIPTION
## Summary

Fixes #7 - Malformed PII tags not being rehydrated when ChatGPT garbles the tag format.

## Problem

When ChatGPT echoes back PII placeholder tags in its response, it sometimes moves the self-closing `/>` inside the `id` attribute value:

| Normal | Malformed |
|--------|-----------|
| `<PII type="PERSON" id="7"/>` | `<PII type="PERSON" id="7/>">` |

This causes rehydration to fail because the fuzzy matching regex didn't account for this malformation pattern.

## Solution

Updated `buildFuzzyTagPatterns()` in `src/pipeline/tagger.ts` to handle malformed id attribute values:

1. **`idAttr` pattern**: Now optionally matches `/`, `/>`, or `/&gt;` (HTML entity) after the digits but before the closing quote
2. **`selfClosing` pattern**: Made the closing `>` optional since it may have been consumed inside the id attribute

## Changes

- `src/pipeline/tagger.ts`: Updated regex patterns in `buildFuzzyTagPatterns()`
- `test/pipeline/tagger.test.ts`: Added 7 new test cases

## Test Coverage

**extractTags tests:**
- Malformed id with `/>` inside quotes (ChatGPT garbling)
- Malformed id with `/` inside quotes
- Malformed id with HTML entity `&gt;` inside quotes
- Mixed normal and malformed tags

**rehydrate tests:**
- Rehydration of malformed tags with `/>` inside id quotes
- Rehydration of malformed tags with HTML entity
- Rehydration of both normal and malformed tags in same text

All 63 tagger tests pass.